### PR TITLE
63 html element closing tag tooltips

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A VS Code extension that provides intelligent language support for Meteor/Blaze 
 - **📐 Template Parameter Completion** - Smart suggestions for template parameters and values during template invocations
 - **🎨 Auto-Formatting** - Automatically formats multi-line template invocations with proper indentation
 - **✨ Auto-Insert End Tags** - Automatically completes Blaze block tags (`{{#if}}` → `{{/if}}`)
+- **🏷️ HTML Element Hints** - Shows class names and IDs at closing tags for long HTML elements
 - **🔍 Cross-file Intelligence** - Analyzes neighboring TypeScript/JavaScript and CSS files for completions
 - **📋 Rich Hover Information** - Shows helper definitions, file locations, and documentation
 - **🎯 Go-to-Definition** - Navigate from helper usage to definition
@@ -40,7 +41,7 @@ A VS Code extension that provides intelligent language support for Meteor/Blaze 
 
    ```javascript
    Template.myTemplate.helpers({
-     helper: () => 'Hello, Meteor!'
+     helper: () => 'Hello, Meteor!',
    });
    ```
 
@@ -114,7 +115,6 @@ Basic configuration in VS Code settings:
       }
     ]
   }
-
 }
 ```
 
@@ -125,9 +125,11 @@ Basic configuration in VS Code settings:
 ### Example Configuration Files
 
 For more configuration examples, see the example files in the [docs directory](./docs/):
+
 - **[example-settings.jsonc](./docs/example-settings.jsonc)** - Basic configuration
 - **[example-settings-auto-insert.jsonc](./docs/example-settings-auto-insert.jsonc)** - Auto-insert end tags
 - **[example-settings-blazeHelpers-colors.jsonc](./docs/example-settings-blazeHelpers-colors.jsonc)** - Custom helper colors
+- **[example-settings-htmlElementHints.jsonc](./docs/example-settings-htmlElementHints.jsonc)** - HTML element closing tag hints
 - **[example-blaze-token-theme.jsonc](./docs/example-blaze-token-theme.jsonc)** - TextMate token customization
 
 📖 **For complete configuration options and advanced features, see [docs/SETUP.md](./docs/SETUP.md)**

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -9,16 +9,20 @@ The extension provides intelligent language support for Meteor/Blaze templates w
 ## Core Features
 
 ### 🎯 Smart Template Detection
+
 The extension automatically detects Meteor projects and activates only when:
+
 - A `.meteor` directory is present in the workspace
 - HTML files contain `<template name="...">` tags
 - Regular HTML files without Meteor templates remain unaffected
 
 **Testing Template Detection:**
+
 - ✅ **Meteor Project**: Extension activates and shows "Meteor/Blaze HTML Language Server activated for Meteor project!"
 - ❌ **Non-Meteor Project**: Extension remains inactive, no Blaze features available
 
 ### 🎨 Syntax Highlighting & Expression Detection
+
 Full support for Blaze templating syntax with intelligent expression detection:
 
 - **Handlebars Expressions**: `{{helper}}`, `{{{rawHtml}}}`
@@ -27,36 +31,46 @@ Full support for Blaze templating syntax with intelligent expression detection:
 - **Comments**: `{{!-- comment --}}`
 
 **Smart Expression Detection:**
+
 - Auto-completion only triggers within `{{}}` or `{{{}}}` expressions
 - Hover information shows only when cursor is inside handlebars expressions
 - No interference with regular HTML content
 
 ### 💡 Intelligent Code Completion
+
 Advanced auto-completion that analyzes neighboring files:
 
 #### Template Helpers
+
 ```javascript
 // template.js
 Template.myTemplate.helpers({
-  userName: () => "John Doe",
+  userName: () => 'John Doe',
   isActive: () => true,
-  formatDate: (date) => new Date(date).toLocaleDateString()
+  formatDate: (date) => new Date(date).toLocaleDateString(),
 });
 ```
 
 #### CSS Classes
+
 ```css
 /* styles.css */
-.user-card { border: 1px solid #ddd; }
-.active-status { color: green; }
+.user-card {
+  border: 1px solid #ddd;
+}
+.active-status {
+  color: green;
+}
 ```
 
 #### Built-in Blaze Helpers
+
 - `#each`, `#if`, `#unless`, `#with`, `#let`
 - `this`, `@index`, `@key`
 - Context-aware suggestions
 
 #### Template Inclusions (`{{> templateName}}`)
+
 Smart template inclusion with import-based filtering:
 
 ```typescript
@@ -68,20 +82,24 @@ import './userProfile/userProfile';
 ```html
 <!-- template.html -->
 <template name="test">
-  {{> }} <!-- Only suggests imported templates: nestedTemplate, userProfile -->
+  {{> }}
+  <!-- Only suggests imported templates: nestedTemplate, userProfile -->
 </template>
 ```
 
 **Features:**
+
 - Analyzes import statements in associated JS/TS files
 - Only suggests templates that are actually imported
 - Supports various import patterns (relative paths, standard Meteor patterns)
 - Provides hover information for template inclusions
 
 #### Template Parameter Completion
+
 Smart completion for template invocation parameters with context-aware suggestions:
 
 **Left Side of `=` (Parameter Names):**
+
 ```typescript
 // childTemplate.ts
 type ChildTemplateData = {
@@ -94,31 +112,33 @@ type ChildTemplateData = {
 ```html
 <!-- template.html -->
 <template name="parent">
-  {{> childTemplate
-    █  <!-- Suggests: childParam=, count=, isActive= -->
+  {{> childTemplate █
+  <!-- Suggests: childParam=, count=, isActive= -->
   }}
 </template>
 ```
 
 **Right Side of `=` (Parameter Values):**
+
 ```typescript
 // parent.ts
 Template.parent.helpers({
-  getUserName: () => "John",
+  getUserName: () => 'John',
   getCount: () => 42,
-  isActive: () => true
+  isActive: () => true,
 });
 ```
 
 ```html
 <template name="parent">
-  {{> childTemplate
-    childParam=█  <!-- Suggests: getUserName, getCount, isActive, this, true, false -->
+  {{> childTemplate childParam=█
+  <!-- Suggests: getUserName, getCount, isActive, this, true, false -->
   }}
 </template>
 ```
 
 **Features:**
+
 - **Parameter Name Completion**: Shows expected parameters from template TypeScript definitions and usage patterns
 - **Value Completion**: Shows helpers, data properties, and context values from the current template
 - **Smart Filtering**: Already-used parameters are excluded from suggestions
@@ -126,12 +146,13 @@ Template.parent.helpers({
 - **Documentation**: Shows JSDoc comments for parameters
 
 **Configuration:**
+
 ```json
 {
   "meteorLanguageServer.completion": {
-    "suggestTemplateParams": true,      // Enable parameter name suggestions
-    "suggestTemplateValues": true,       // Enable value suggestions
-    "parameterInferenceMinUsage": 2     // Min usage count for inference
+    "suggestTemplateParams": true, // Enable parameter name suggestions
+    "suggestTemplateValues": true, // Enable value suggestions
+    "parameterInferenceMinUsage": 2 // Min usage count for inference
   }
 }
 ```
@@ -143,27 +164,33 @@ Automatically inserts closing tags for Blaze block helpers, reducing errors and 
 ### How It Works
 
 #### Primary Method: Completion Within Opening Block
+
 When you have an incomplete opening block, press **Ctrl+Space** anywhere within the brackets:
 
 ```html
-{{#if condition|}}  <!-- Press Ctrl+Space here -->
+{{#if condition|}}
+<!-- Press Ctrl+Space here -->
 ```
 
 Shows completion: "Add closing {{/if}}"
 
 #### Secondary Method: Space-Triggered Completion
+
 After typing a block name with space:
 
 ```html
-{{#if   <!-- Press Ctrl+Space after space -->
+{{#if
+<!-- Press Ctrl+Space after space -->
 ```
 
 Shows full block structure completion.
 
 #### Discovery Mode
+
 Type `{{#` and press Ctrl+Space to see all available block types.
 
 ### Supported Blocks
+
 - `{{#if}}` → `{{/if}}`
 - `{{#unless}}` → `{{/unless}}`
 - `{{#each}}` → `{{/each}}`
@@ -171,15 +198,16 @@ Type `{{#` and press Ctrl+Space to see all available block types.
 - Custom blocks (configurable)
 
 ### Configuration
+
 ```json
 {
   "meteorLanguageServer.blockConditions": {
-    "autoInsertEndTags": true,  // Enable/disable globally
+    "autoInsertEndTags": true, // Enable/disable globally
     "extend": [
       {
         "type": "customBlock",
         "label": "Custom Block",
-        "autoInsertEndTag": true  // Per-block control
+        "autoInsertEndTag": true // Per-block control
       }
     ]
   }
@@ -187,6 +215,7 @@ Type `{{#` and press Ctrl+Space to see all available block types.
 ```
 
 ### Smart Behavior
+
 - Only offers completion for blocks missing closing tags
 - Works correctly with nested blocks
 - Includes snippet navigation with Tab between placeholders
@@ -199,28 +228,125 @@ Visual inline hints that show the condition for closing block tags.
 ### Visual Examples
 
 ```html
+{{#if user.isActive}}
+<div>User is active</div>
+{{/if}} // END if user.isActive {{#each items}}
+<li>{{name}}</li>
+{{/each}} // END each items
+```
+
+## 🏷️ HTML Element Closing Tag Hints
+
+Visual inline hints showing class names and IDs at the closing tags of HTML elements that span multiple lines. This feature helps you quickly identify which element is closing in deeply nested HTML structures.
+
+### Visual Examples
+
+```html
+<div id="main" class="container primary">
+  <header class="site-header">
+    <nav>Navigation content</nav>
+    <!-- many lines -->
+  </header>
+  // END: header.site-header
+
+  <div class="content-wrapper">
+    <!-- many lines of content -->
+  </div>
+  // END: div.content-wrapper
+</div>
+// END: div#main.container.primary
+```
+
+### Features
+
+- **CSS Selector Format**: Displays hints in familiar CSS notation (e.g., `div#id.class1.class2`)
+- **Smart Filtering**: Prioritizes custom classes over Bootstrap utility classes when truncating
+- **Configurable Threshold**: Only shows hints for elements spanning a minimum number of lines (default: 15)
+- **Respects Existing Comments**: Won't add hints if a comment already exists on the line
+- **Self-Closing Tags Excluded**: Automatically skips `<img>`, `<br>`, `<input>`, etc.
+- **Nested Element Support**: Properly handles deeply nested structures with same tag names
+
+### Configuration
+
+```json
+{
+  "meteorLanguageServer.htmlElementHints": {
+    "enabled": true, // Enable/disable the feature
+    "minimumLines": 15, // Minimum lines to show hint (default: 15)
+    "color": "#727272", // Hint color (hex or theme color)
+    "fontStyle": "italic", // Font style: normal, italic, or bold
+    "margin": "0 0 0 0.75em", // CSS margin for hints
+    "showClasses": true, // Include class names in hints
+    "showIds": true, // Include IDs in hints
+    "maxClassesToShow": 3 // Max classes to display (0 = unlimited)
+  }
+}
+```
+
+### Smart Class Filtering
+
+When elements have many classes, the feature intelligently filters them:
+
+```html
+<!-- Element with many classes including Bootstrap utilities -->
+<div
+  class="my-component container row d-flex justify-content-center custom-style"
+>
+  <!-- many lines -->
+</div>
+// END: div.my-component.custom-style.container...
+```
+
+**Bootstrap classes are filtered out first**, showing your custom semantic classes:
+
+- ✅ Shows: `my-component`, `custom-style`, `container`
+- ❌ Hidden: `row`, `d-flex`, `justify-content-center` (Bootstrap utilities)
+
+This keeps hints focused on the meaningful class names that identify the component.
+
+### Display Rules
+
+- ✅ Shows hints for elements spanning 15+ lines (configurable)
+- ✅ Displays id as `#id` (CSS selector style)
+- ✅ Displays classes as `.class1.class2` (CSS selector style)
+- ✅ Filters out Handlebars expressions in class/id attributes
+- ❌ No hints when comment already exists on closing tag
+- ❌ No hints for self-closing elements (`<img />`, `<br />`, etc.)
+- ❌ No hints for elements below minimum line threshold
+
+## 📋 Block Condition Hints (continued)
+
+### Visual Examples
+
+```html
 {{#if userIsActive}}
-  <p>User is active</p>
-{{else}}         <!-- NOT userIsActive (hint appears) -->
-  <p>User is inactive</p>
-{{/if}}          <!-- END if userIsActive (hint appears) -->
+<p>User is active</p>
+{{else}}
+<!-- NOT userIsActive (hint appears) -->
+<p>User is inactive</p>
+{{/if}}
+<!-- END if userIsActive (hint appears) -->
 
 {{#each item in items}}
-  <div>{{item.name}}</div>
-{{/each}}        <!-- END each item in items (hint appears) -->
+<div>{{item.name}}</div>
+{{/each}}
+<!-- END each item in items (hint appears) -->
 
 {{#unless loading}}
-  <p>Content loaded</p>
-{{/unless}}      <!-- END unless loading (hint appears) -->
+<p>Content loaded</p>
+{{/unless}}
+<!-- END unless loading (hint appears) -->
 ```
 
 ### Hint Display Rules
+
 - ✅ **Shows hints** when no existing comment on the closing tag
 - ❌ **No hints** when comment already exists: `{{/if}} <!-- custom comment -->`
 - ✅ **Context-aware** shows appropriate condition text
 - ✅ **Styled** with configurable colors and fonts
 
 ### Configuration
+
 ```json
 {
   "meteorLanguageServer.blockConditions": {
@@ -239,9 +365,11 @@ Automatic formatting for multi-line template invocations with proper indentation
 ### How It Works
 
 #### Format on Save
+
 When you save a file, template invocations are automatically formatted:
 
 **Before:**
+
 ```html
 <template name="myTemplate">
   {{> childTemplate param1=value1 param2=value2 param3=value3}}
@@ -249,30 +377,32 @@ When you save a file, template invocations are automatically formatted:
 ```
 
 **After:**
+
 ```html
 <template name="myTemplate">
-  {{> childTemplate
-    param1=value1
-    param2=value2
-    param3=value3
-  }}
+  {{> childTemplate param1=value1 param2=value2 param3=value3 }}
 </template>
 ```
 
 #### Format on Type
+
 Formatting also triggers when:
+
 - Pressing **Enter** inside a template invocation
 - Typing the closing `}}`
 
 **Example (pressing Enter):**
+
 ```html
-{{> myTemplate|  <!-- Press Enter here -->
+{{> myTemplate|
+<!-- Press Enter here -->
 ```
 
 Automatically indents the next line:
+
 ```html
-{{> myTemplate
-  █  <!-- Cursor positioned with proper indentation -->
+{{> myTemplate █
+<!-- Cursor positioned with proper indentation -->
 ```
 
 ### Formatting Rules
@@ -285,24 +415,18 @@ Automatically indents the next line:
 ### Examples
 
 **Nested in HTML:**
+
 ```html
 <div class="container">
-  {{> userCard
-    name=userName
-    email=userEmail
-    active=isActive
-  }}
+  {{> userCard name=userName email=userEmail active=isActive }}
 </div>
 ```
 
 **Complex Parameters:**
+
 ```html
-{{> templateName
-  simpleParam=value
-  helperParam=(getHelper)
-  subexpressionParam=(add 1 2)
-  stringParam="text value"
-}}
+{{> templateName simpleParam=value helperParam=(getHelper)
+subexpressionParam=(add 1 2) stringParam="text value" }}
 ```
 
 ### Configuration
@@ -310,19 +434,21 @@ Automatically indents the next line:
 ```json
 {
   "meteorLanguageServer.formatting": {
-    "enabled": true,      // Enable automatic formatting
-    "indentSize": 2       // Spaces for indentation (when using spaces)
+    "enabled": true, // Enable automatic formatting
+    "indentSize": 2 // Spaces for indentation (when using spaces)
   }
 }
 ```
 
 **VS Code Settings:**
 Your editor's formatting settings are also respected:
+
 - `editor.tabSize` - Indent size
 - `editor.insertSpaces` - Use spaces vs tabs
 - `editor.formatOnSave` - Format when saving
 
 ### Smart Behavior
+
 - ✅ Only formats multi-line invocations
 - ✅ Preserves single-line invocations when appropriate
 - ✅ Handles nested template invocations correctly
@@ -334,28 +460,31 @@ Your editor's formatting settings are also respected:
 Analyzes neighboring files in the same directory for comprehensive language support:
 
 ### File Analysis
+
 - **JavaScript/TypeScript files**: Parses `Template.templateName.helpers()` definitions
 - **CSS/LESS files**: Extracts class definitions for auto-completion
 - **Directory-scoped**: Only includes files from the same directory as the template
 
 ### Helper Analysis
+
 Supports both JavaScript and TypeScript with complex parsing:
 
 ```typescript
 // Advanced TypeScript parsing
 Template.myTemplate.helpers({
   complexHelper: (): HelperResult => {
-    const data = { nested: { braces: "work fine" } };
+    const data = { nested: { braces: 'work fine' } };
     return processData(data);
   },
 
   simpleHelper() {
-    return "Simple helper";
-  }
+    return 'Simple helper';
+  },
 });
 ```
 
 ### Benefits
+
 - **Hover Information**: Shows helper definitions, file locations, and JSDoc
 - **Go-to-Definition**: Navigate from helper usage to definition
 - **Real-time Updates**: Automatically detects file changes
@@ -366,6 +495,7 @@ Template.myTemplate.helpers({
 Intelligent validation that detects missing or mismatched Blaze block end tags:
 
 ### Validation Features
+
 - Detects missing closing tags (`{{#if}}` without `{{/if}}`)
 - Identifies mismatched block types
 - Shows clear error messages with context
@@ -387,6 +517,7 @@ You can also manually trigger workspace validation at any time:
 3. Check the Problems panel for results
 
 **Configuration:**
+
 ```json
 {
   // Enable/disable automatic validation on startup (default: true)
@@ -398,23 +529,27 @@ You can also manually trigger workspace validation at any time:
 ```
 
 **Benefits:**
+
 - ✅ Find errors across your entire project without opening each file
 - ✅ See all validation errors in one centralized Problems panel
 - ✅ Click on any error to jump directly to the problematic code
 - ✅ Particularly useful for large projects with many template files
 
 ### Error Examples
+
 ```html
 {{#if condition}}
-  <p>Content</p>
+<p>Content</p>
 <!-- Missing {{/if}} - shows validation error -->
 
 {{#each items}}
-  <div>{{this}}</div>
-{{/if}}  <!-- Mismatch: /if should be /each - shows error -->
+<div>{{this}}</div>
+{{/if}}
+<!-- Mismatch: /if should be /each - shows error -->
 ```
 
 ### Configuration
+
 ```json
 {
   "meteorLanguageServer.maxNumberOfProblems": 100,
@@ -422,7 +557,7 @@ You can also manually trigger workspace validation at any time:
     "extend": [
       {
         "type": "customBlock",
-        "requiresEndTag": true  // Enable validation for custom blocks
+        "requiresEndTag": true // Enable validation for custom blocks
       }
     ]
   }
@@ -432,6 +567,7 @@ You can also manually trigger workspace validation at any time:
 ## 🛠️ Advanced Configuration
 
 ### Custom Block Types
+
 Extend the extension with custom block helpers:
 
 ```json
@@ -441,8 +577,8 @@ Extend the extension with custom block helpers:
       {
         "type": "customHelper",
         "label": "Custom Helper Block",
-        "requiresEndTag": true,      // Validation
-        "autoInsertEndTag": true     // Auto-insertion
+        "requiresEndTag": true, // Validation
+        "autoInsertEndTag": true // Auto-insertion
       }
     ]
   }
@@ -450,6 +586,7 @@ Extend the extension with custom block helpers:
 ```
 
 ### Custom Global Helpers with Rich Documentation
+
 Define custom global helpers with complete documentation, parameter types, return types, and examples:
 
 ```json
@@ -489,12 +626,14 @@ Define custom global helpers with complete documentation, parameter types, retur
 ```
 
 **Benefits:**
+
 - **Rich Hover Information**: See full documentation with parameter types and examples
 - **Better IntelliSense**: Parameter information displayed in completions
 - **Type Safety**: Document expected types for better code quality
 - **Team Collaboration**: Share helper documentation across your team
 
 ### Custom Blaze Helpers (Legacy)
+
 Simple helper configuration with name and doc only:
 
 ```json
@@ -519,12 +658,14 @@ For more advanced documentation, use `globalHelpers` instead.
 ## 📊 Performance & Optimization
 
 ### Performance Features
+
 - **Lazy Loading**: Features activate only when needed
 - **Incremental Parsing**: Analyzes changes incrementally
 - **Directory Scoping**: Limits analysis to relevant files
 - **Caching**: Caches parsed results for better performance
 
 ### Optimization Tips
+
 1. **Limit Problem Count**: Reduce `maxNumberOfProblems` for large projects
 2. **Disable Tracing**: Set `trace.server` to `"off"` in production
 3. **Organize Files**: Keep template-related files in the same directory
@@ -535,32 +676,41 @@ For more advanced documentation, use `globalHelpers` instead.
 To test all features are working correctly:
 
 ### 1. Template Detection Test
+
 - Open a Meteor project (with `.meteor` directory)
 - Verify activation message appears
 - Open HTML file with `<template name="...">` tags
 
 ### 2. Auto-completion Test
+
 ```html
 <template name="test">
-  {{  <!-- Type and press Ctrl+Space - should show helpers -->
+  {{
+  <!-- Type and press Ctrl+Space - should show helpers -->
 </template>
 ```
 
 ### 3. Block Hints Test
+
 ```html
 {{#if someCondition}}
-  <p>Content</p>
-{{/if}}  <!-- Should show: END if someCondition -->
+<p>Content</p>
+{{/if}}
+<!-- Should show: END if someCondition -->
 ```
 
 ### 4. Auto-insert Test
+
 ```html
-{{#if condition  <!-- Press Ctrl+Space - should offer closing tag -->
+{{#if condition
+<!-- Press Ctrl+Space - should offer closing tag -->
 ```
 
 ### 5. Template Inclusion Test
+
 ```html
-{{>   <!-- Press Ctrl+Space - should show imported templates only -->
+{{>
+<!-- Press Ctrl+Space - should show imported templates only -->
 ```
 
 ## Related Documentation

--- a/docs/example-settings-htmlElementHints.jsonc
+++ b/docs/example-settings-htmlElementHints.jsonc
@@ -1,0 +1,182 @@
+{
+  // ============================================================
+  // HTML Element Closing Tag Hints Configuration Examples
+  // ============================================================
+  // Visual inline hints showing class names and IDs at closing tags
+  // of HTML elements that span multiple lines.
+  //
+  // Copy these settings to your VS Code settings.json file
+  // ============================================================
+
+  // ------------------------------------------------------------
+  // Example 1: Default Configuration (Recommended)
+  // ------------------------------------------------------------
+  // Shows hints for elements spanning 15+ lines
+  // with up to 3 classes displayed
+  "meteorLanguageServer.htmlElementHints": {
+    "enabled": true,
+    "minimumLines": 15,
+    "color": "#727272",
+    "fontStyle": "italic",
+    "margin": "0 0 0 0.75em",
+    "showClasses": true,
+    "showIds": true,
+    "maxClassesToShow": 3,
+  },
+
+  // ------------------------------------------------------------
+  // Example 2: Show More Classes
+  // ------------------------------------------------------------
+  // Display up to 5 classes before truncating
+  "meteorLanguageServer.htmlElementHints": {
+    "enabled": true,
+    "minimumLines": 15,
+    "maxClassesToShow": 5, // Show more classes
+    "color": "#727272",
+    "fontStyle": "italic",
+  },
+
+  // ------------------------------------------------------------
+  // Example 3: Show All Classes (No Truncation)
+  // ------------------------------------------------------------
+  // Display all classes without truncation
+  "meteorLanguageServer.htmlElementHints": {
+    "enabled": true,
+    "minimumLines": 15,
+    "maxClassesToShow": 0, // 0 = unlimited
+    "color": "#727272",
+    "fontStyle": "italic",
+  },
+
+  // ------------------------------------------------------------
+  // Example 4: Lower Threshold for Shorter Elements
+  // ------------------------------------------------------------
+  // Show hints for elements spanning just 5+ lines
+  "meteorLanguageServer.htmlElementHints": {
+    "enabled": true,
+    "minimumLines": 5, // Lower threshold
+    "maxClassesToShow": 3,
+    "color": "#727272",
+    "fontStyle": "italic",
+  },
+
+  // ------------------------------------------------------------
+  // Example 5: ID Only (No Classes)
+  // ------------------------------------------------------------
+  // Only show element IDs, hide class names
+  "meteorLanguageServer.htmlElementHints": {
+    "enabled": true,
+    "minimumLines": 15,
+    "showIds": true,
+    "showClasses": false, // Hide class names
+    "color": "#727272",
+    "fontStyle": "italic",
+  },
+
+  // ------------------------------------------------------------
+  // Example 6: Classes Only (No IDs)
+  // ------------------------------------------------------------
+  // Only show class names, hide IDs
+  "meteorLanguageServer.htmlElementHints": {
+    "enabled": true,
+    "minimumLines": 15,
+    "showIds": false, // Hide IDs
+    "showClasses": true,
+    "maxClassesToShow": 3,
+    "color": "#727272",
+    "fontStyle": "italic",
+  },
+
+  // ------------------------------------------------------------
+  // Example 7: Custom Styling (Bold Green)
+  // ------------------------------------------------------------
+  // Use bold green hints with custom spacing
+  "meteorLanguageServer.htmlElementHints": {
+    "enabled": true,
+    "minimumLines": 15,
+    "color": "#4CAF50", // Green color
+    "fontStyle": "bold", // Bold instead of italic
+    "margin": "0 0 0 1em", // More spacing
+    "maxClassesToShow": 3,
+  },
+
+  // ------------------------------------------------------------
+  // Example 8: Subtle Hints
+  // ------------------------------------------------------------
+  // Very subtle, low-contrast hints
+  "meteorLanguageServer.htmlElementHints": {
+    "enabled": true,
+    "minimumLines": 20, // Only very long elements
+    "color": "#555555", // Darker, subtle color
+    "fontStyle": "normal", // Normal text
+    "margin": "0 0 0 0.5em",
+    "maxClassesToShow": 2, // Fewer classes
+  },
+
+  // ------------------------------------------------------------
+  // Example 9: Theme-Aware Color
+  // ------------------------------------------------------------
+  // Use VS Code theme colors instead of fixed hex colors
+  "meteorLanguageServer.htmlElementHints": {
+    "enabled": true,
+    "minimumLines": 15,
+    "color": "editorCodeLens.foreground", // Use theme color
+    "fontStyle": "italic",
+    "maxClassesToShow": 3,
+  },
+
+  // ------------------------------------------------------------
+  // Example 10: Minimal Configuration
+  // ------------------------------------------------------------
+  // All defaults, just enable or adjust one setting
+  "meteorLanguageServer.htmlElementHints": {
+    "enabled": true,
+    "minimumLines": 20, // Only this changed from default
+  },
+
+  // ------------------------------------------------------------
+  // Example 11: Disabled
+  // ------------------------------------------------------------
+  // Turn off HTML element hints completely
+  "meteorLanguageServer.htmlElementHints": {
+    "enabled": false,
+  },
+
+  // ============================================================
+  // Visual Output Examples
+  // ============================================================
+  // These show what you'll see in your editor:
+  //
+  // Example with ID and classes:
+  // </div> // END: div#main.container.primary
+  //
+  // Example with classes only:
+  // </section> // END: section.hero.full-width.dark-theme
+  //
+  // Example with ID only:
+  // </article> // END: article#post-123
+  //
+  // Example with truncation:
+  // </div> // END: div.component.wrapper.container...
+  //
+  // ============================================================
+
+  // ============================================================
+  // Tips
+  // ============================================================
+  // 1. Bootstrap classes are automatically filtered out first
+  //    when truncating, keeping your custom semantic classes visible
+  //
+  // 2. Hints won't appear if you already have a comment on that line
+  //
+  // 3. Self-closing tags (<img>, <br>, etc.) never get hints
+  //
+  // 4. Use minimumLines to control how much code needs to be
+  //    inside an element before showing a hint
+  //
+  // 5. Set maxClassesToShow to 0 for unlimited class display
+  //
+  // 6. Combine with block condition hints for complete visual
+  //    context in your templates
+  // ============================================================
+}

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "pretest": "npm run compile:tests && npm run lint",
     "check-types": "tsc --noEmit",
     "lint": "eslint src",
-    "test": "node --enable-source-maps --test out/test/server/**/*.test.js",
+    "test": "node --enable-source-maps --test 'out/test/server/**/*.test.js'",
     "test-manual": "node --enable-source-maps out/test/runTest.js",
     "prettier:check": "prettier --check \"src/**/*.ts\" \"src/test/**/*.ts\" \"*.json\""
   },
@@ -560,6 +560,58 @@
               "type": "number",
               "default": 2,
               "description": "Minimum usage count to suggest parameters inferred from template usage patterns"
+            }
+          }
+        },
+        "meteorLanguageServer.htmlElementHints": {
+          "type": "object",
+          "default": {},
+          "description": "Settings for HTML element closing tag hints.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Enable/disable HTML element closing tag hints"
+            },
+            "minimumLines": {
+              "type": "number",
+              "default": 15,
+              "description": "Minimum number of lines an element must span to show closing hint"
+            },
+            "color": {
+              "type": "string",
+              "default": "#727272",
+              "description": "Color for HTML element hints. Can be a theme color name or hex color"
+            },
+            "fontStyle": {
+              "type": "string",
+              "enum": [
+                "normal",
+                "italic",
+                "bold"
+              ],
+              "default": "italic",
+              "description": "Font style for HTML element hints"
+            },
+            "margin": {
+              "type": "string",
+              "default": "0 0 0 0.75em",
+              "description": "CSS margin for HTML element hints"
+            },
+            "showClasses": {
+              "type": "boolean",
+              "default": true,
+              "description": "Include class names in the hint"
+            },
+            "showIds": {
+              "type": "boolean",
+              "default": true,
+              "description": "Include IDs in the hint"
+            },
+            "maxClassesToShow": {
+              "type": "number",
+              "default": 3,
+              "description": "Maximum number of classes to display (0 = unlimited)"
             }
           }
         }

--- a/src/extension/activate.ts
+++ b/src/extension/activate.ts
@@ -16,6 +16,11 @@ import {
   updateBlockConditionDecorations,
   updateDecorationType,
 } from './helpers/blockConditions/decorationType';
+import {
+  createHtmlElementDecorationType,
+  updateDecorationType as updateHtmlElementDecorationType,
+  updateHtmlElementDecorations,
+} from './helpers/htmlElements/decorationType';
 import { isMeteorProject } from './helpers/meteor';
 
 const ACTIVATE_CONFIGS = {
@@ -85,6 +90,9 @@ export const createActivate = (extConfig: ExtensionConfig) => {
     // Initialize decoration type with current settings
     extConfig.blockConditionDecorationType =
       createBlockConditionDecorationType();
+
+    // Initialize HTML element decoration type with current settings
+    extConfig.htmlElementDecorationType = createHtmlElementDecorationType();
 
     // The server is implemented in node
     const serverModule = context.asAbsolutePath(path.join('dist', 'server.js'));
@@ -305,6 +313,7 @@ export const createActivate = (extConfig: ExtensionConfig) => {
         event.document.languageId === 'handlebars'
       ) {
         updateBlockConditionDecorations(extConfig, event.document);
+        updateHtmlElementDecorations(extConfig, event.document);
       }
     });
 
@@ -317,6 +326,7 @@ export const createActivate = (extConfig: ExtensionConfig) => {
             editor.document.languageId === 'handlebars')
         ) {
           updateBlockConditionDecorations(extConfig, editor.document);
+          updateHtmlElementDecorations(extConfig, editor.document);
         }
       }
     );
@@ -324,6 +334,10 @@ export const createActivate = (extConfig: ExtensionConfig) => {
     // Update decorations for current active editor
     if (vscode.window.activeTextEditor) {
       updateBlockConditionDecorations(
+        extConfig,
+        vscode.window.activeTextEditor.document
+      );
+      updateHtmlElementDecorations(
         extConfig,
         vscode.window.activeTextEditor.document
       );
@@ -336,6 +350,11 @@ export const createActivate = (extConfig: ExtensionConfig) => {
           event.affectsConfiguration('meteorLanguageServer.blockConditions')
         ) {
           updateDecorationType(extConfig);
+        }
+        if (
+          event.affectsConfiguration('meteorLanguageServer.htmlElementHints')
+        ) {
+          updateHtmlElementDecorationType(extConfig);
         }
       }
     );

--- a/src/extension/deactivate.ts
+++ b/src/extension/deactivate.ts
@@ -7,9 +7,9 @@ import { ExtensionConfig } from '../types';
  */
 export const createDeactivate = (extConfig: ExtensionConfig) => {
   return (): Thenable<void> | undefined => {
-    // Dispose decoration type
-
+    // Dispose decoration types
     extConfig.blockConditionDecorationType?.dispose();
+    extConfig.htmlElementDecorationType?.dispose();
 
     if (!extConfig.client) {
       return undefined;

--- a/src/extension/helpers/blockConditions/decorationType.ts
+++ b/src/extension/helpers/blockConditions/decorationType.ts
@@ -2,6 +2,7 @@ import vscode from 'vscode';
 
 import { ExtensionConfig } from '../../../types';
 
+import { codeBlock, codeInline } from '../../../server/helpers/strings';
 import { isWithinComment } from '../activate/isWithinComment';
 import { containsMeteorTemplates } from '../meteor';
 import { findEnclosingBlockForElseWithIndex } from './findEnclosingBlockForElse';
@@ -176,6 +177,8 @@ export const updateBlockConditionDecorations = (
         if (lineHasExistingComment(text, endPos)) {
           continue;
         }
+        const startLineNumber = startPos.line + 1;
+        const endLineNumber = endPos.line + 1;
 
         decorations.push({
           range: new vscode.Range(endPos, endPos),
@@ -184,6 +187,17 @@ export const updateBlockConditionDecorations = (
               contentText: `// END ${label}${propText} ${matchResult.condition}`,
             },
           },
+          hoverMessage: [
+            `Matches the opening ${codeInline(`{{#${label}${propText} ${matchResult.condition}}}`)} at line ${startLineNumber}`,
+            codeBlock(
+              'handlebars',
+              [
+                `${startLineNumber} {{#${label}${propText} ${matchResult.condition}}}`,
+                `∞    ...`,
+                `${endLineNumber} {{/${label}}`,
+              ].join('\n')
+            ),
+          ],
         });
       }
     }

--- a/src/extension/helpers/htmlElements/decorationType.ts
+++ b/src/extension/helpers/htmlElements/decorationType.ts
@@ -1,0 +1,254 @@
+import vscode from 'vscode';
+
+import { codeBlock, startCase } from '../../../server/helpers/strings';
+import { ExtensionConfig } from '../../../types';
+import { isWithinComment } from '../activate/isWithinComment';
+import { findMatchingOpenTag } from './findMatchingOpenTag';
+import { formatHintText, parseHtmlAttributes } from './parseHtmlAttributes';
+
+/**
+ * Check if a line already contains a comment (HTML or Handlebars comment).
+ * This helps avoid adding HTML element hints when there's already a comment on the line.
+ *
+ * @param text The full document text
+ * @param position The position to check from
+ * @returns true if the line contains a comment after the position
+ */
+const lineHasExistingComment = (
+  text: string,
+  position: vscode.Position
+): boolean => {
+  const lines = text.split('\n');
+  if (position.line >= lines.length) {
+    return false;
+  }
+
+  const lineText = lines[position.line];
+  const afterPosition = lineText.substring(position.character);
+
+  // Check for HTML comments: <!-- anything -->
+  const hasHtmlComment =
+    /<!--.*?-->/.test(afterPosition) || /<!--/.test(afterPosition);
+
+  // Check for Handlebars comments: {{!-- anything --}} or {{! anything }}
+  const hasHandlebarsComment =
+    /\{\{!--.*?--\}\}/.test(afterPosition) ||
+    /\{\{!.*?\}\}/.test(afterPosition) ||
+    /\{\{!--/.test(afterPosition) ||
+    /\{\{!/.test(afterPosition);
+
+  return hasHtmlComment || hasHandlebarsComment;
+};
+
+/**
+ * Update HTML element decorations in the active editor for the given document.
+ * This will add hints for HTML closing tags with their id/class info.
+ *
+ * @param extConfig The extension configuration containing the decoration type
+ * @param document The document to update decorations for
+ */
+export const updateHtmlElementDecorations = (
+  extConfig: ExtensionConfig,
+  document: vscode.TextDocument
+) => {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || editor.document !== document) {
+    return;
+  }
+
+  // Only provide decorations for HTML template files
+  const uri = document.uri.toString();
+  const isHtmlFile = /\.(html|htm|meteor|hbs)$/i.test(uri);
+  if (!isHtmlFile) {
+    const decorationType = extConfig.htmlElementDecorationType;
+    if (decorationType) {
+      editor.setDecorations(decorationType, []);
+    }
+    return;
+  }
+
+  // Check if HTML element hints are enabled
+  const htmlConfig = vscode.workspace.getConfiguration(
+    'meteorLanguageServer.htmlElementHints'
+  );
+  const enabled = htmlConfig.get<boolean>('enabled', true);
+
+  const decorationType = extConfig.htmlElementDecorationType;
+  if (!enabled) {
+    if (decorationType) {
+      editor.setDecorations(decorationType, []);
+    }
+    return;
+  }
+
+  // Get configuration values
+  const minimumLines = htmlConfig.get<number>('minimumLines', 15);
+  const showIds = htmlConfig.get<boolean>('showIds', true);
+  const showClasses = htmlConfig.get<boolean>('showClasses', true);
+  const maxClassesToShow = htmlConfig.get<number>('maxClassesToShow', 3);
+
+  const text = document.getText();
+  const decorations: vscode.DecorationOptions[] = [];
+
+  // Find all closing tags: </tagName>
+  const closingTagRegex = /<\/(\w+)\s*>/g;
+  let match;
+
+  while ((match = closingTagRegex.exec(text)) !== null) {
+    const tagName = match[1];
+    const closingPosition = match.index;
+
+    // Skip if within comment
+    if (isWithinComment(text, closingPosition).isWithin) {
+      continue;
+    }
+
+    // Find matching opening tag
+    const openingTagInfo = findMatchingOpenTag(text, closingPosition, tagName);
+    if (!openingTagInfo) {
+      continue;
+    }
+
+    // Calculate line span
+    const openingPos = document.positionAt(openingTagInfo.position);
+    const closingPos = document.positionAt(closingPosition);
+    const lineSpan = closingPos.line - openingPos.line;
+
+    // Skip if below minimum line threshold
+    if (lineSpan < minimumLines) {
+      continue;
+    }
+
+    // Skip if opening and closing on same line
+    if (openingPos.line === closingPos.line) {
+      continue;
+    }
+
+    // Position after the closing tag
+    const afterClosingTag = document.positionAt(
+      closingPosition + match[0].length
+    );
+
+    // Skip if line already has comment
+    if (lineHasExistingComment(text, afterClosingTag)) {
+      continue;
+    }
+
+    // Parse opening tag attributes
+    const attributes = parseHtmlAttributes(openingTagInfo.openingTag);
+
+    // Only add decoration if there's meaningful info to display
+    if (!attributes.id && attributes.classes.length === 0) {
+      continue;
+    }
+
+    // Format hint text
+    const hintText = formatHintText(
+      attributes.tagName,
+      attributes.id,
+      attributes.classes,
+      { showIds, showClasses, maxClassesToShow }
+    );
+
+    const className = attributes.classes.filter((v) => !!v.trim()).join(' ');
+
+    const lineOfStartTag = openingPos.line + 1;
+    const lineOfEndTag = closingPos.line + 1;
+    const linesRange = [
+      lineOfStartTag,
+      lineOfStartTag !== lineOfEndTag ? lineOfEndTag : null,
+    ]
+      .filter(Boolean)
+      .join('-');
+
+    const formattedTagName =
+      attributes.tagName.length < 3
+        ? attributes.tagName.toUpperCase()
+        : startCase(attributes.tagName);
+
+    // Create decoration for HTML end tag
+    decorations.push({
+      range: new vscode.Range(afterClosingTag, afterClosingTag),
+      renderOptions: {
+        before: { contentText: '' },
+        after: { contentText: `</end ${hintText}>` },
+      },
+      hoverMessage: [
+        `End of HTML Element ${linesRange}`,
+        codeBlock(
+          'typescript',
+          `(element) ${attributes.tagName}: HTML${formattedTagName}Element`
+        ),
+        codeBlock(
+          'html',
+          [
+            `<${attributes.tagName} id="${attributes.id ?? ''}"`,
+            `  class="${className}"`,
+            `>`,
+          ]
+            .map((v, i) => `${lineOfStartTag + i} ${v}`)
+            .join('\n')
+        ),
+      ],
+    });
+  }
+
+  // Apply decorations
+  if (extConfig.htmlElementDecorationType) {
+    editor.setDecorations(extConfig.htmlElementDecorationType, decorations);
+  }
+};
+
+/**
+ * Create a decoration type for HTML element hints based on user settings.
+ * This includes color, font style, and margin.
+ *
+ * @returns A TextEditorDecorationType for HTML element hints
+ */
+export const createHtmlElementDecorationType =
+  (): vscode.TextEditorDecorationType => {
+    const config = vscode.workspace.getConfiguration(
+      'meteorLanguageServer.htmlElementHints'
+    );
+
+    // Get settings with fallbacks
+    const colorSetting = config.get<string>('color', '#72727280');
+    const fontStyle = config.get<string>('fontStyle', 'italic');
+    const margin = config.get<string>('margin', '0 0 0 0.75em');
+
+    // Handle color setting - can be theme color name or hex color
+    const isHex = colorSetting?.startsWith('#');
+
+    const color = isHex ? colorSetting : new vscode.ThemeColor(colorSetting);
+
+    return vscode.window.createTextEditorDecorationType({
+      after: { color, fontStyle, margin },
+      before: { color, fontStyle, margin },
+      rangeBehavior: vscode.DecorationRangeBehavior.ClosedOpen,
+    });
+  };
+
+/**
+ * Update the decoration type for HTML element hints based on current configuration.
+ * This is called when the extension is activated or configuration changes.
+ *
+ * @param extConfig The extension configuration object
+ */
+export const updateDecorationType = (extConfig: ExtensionConfig) => {
+  // Dispose old decoration type if it exists
+  extConfig.htmlElementDecorationType?.dispose();
+
+  // Create new decoration type with current settings
+  extConfig.htmlElementDecorationType = createHtmlElementDecorationType();
+
+  // Update decorations for all visible editors
+  vscode.window.visibleTextEditors.forEach((editor) => {
+    if (
+      ['html', 'handlebars', 'meteor-html', 'meteor-handlebars'].includes(
+        editor.document.languageId
+      )
+    ) {
+      updateHtmlElementDecorations(extConfig, editor.document);
+    }
+  });
+};

--- a/src/extension/helpers/htmlElements/findMatchingOpenTag.ts
+++ b/src/extension/helpers/htmlElements/findMatchingOpenTag.ts
@@ -1,0 +1,90 @@
+/**
+ * Set of self-closing HTML tags that should be skipped
+ */
+const SELF_CLOSING_TAGS = new Set([
+  'img',
+  'br',
+  'hr',
+  'input',
+  'meta',
+  'link',
+  'area',
+  'base',
+  'col',
+  'embed',
+  'param',
+  'source',
+  'track',
+  'wbr',
+]);
+
+/**
+ * Find the matching opening tag for a closing tag using stack-based matching
+ * @param text - Full document text
+ * @param closingTagPosition - Offset of the closing tag
+ * @param tagName - The tag name to match (e.g., 'div')
+ * @returns Object with opening tag text and position, or null
+ */
+export function findMatchingOpenTag(
+  text: string,
+  closingTagPosition: number,
+  tagName: string
+): { openingTag: string; position: number } | null {
+  // Skip self-closing tags
+  if (SELF_CLOSING_TAGS.has(tagName.toLowerCase())) {
+    return null;
+  }
+
+  const beforeClosingTag = text.substring(0, closingTagPosition);
+
+  // Stack to track nested tags of the same type
+  let depth = 0;
+
+  // Regex to find all opening and closing tags of this type
+  // This matches: <tagName ...> and </tagName>
+  const openingTagRegex = new RegExp(`<${tagName}([^>]*?)(/?)>`, 'gi');
+  const closingTagRegex = new RegExp(`</${tagName}\\s*>`, 'gi');
+
+  // Create an array of all tags with their positions and types
+  const tags: Array<{
+    pos: number;
+    isClosing: boolean;
+    match: RegExpExecArray;
+  }> = [];
+
+  let match;
+  while ((match = openingTagRegex.exec(beforeClosingTag)) !== null) {
+    // Check if it's self-closing (ends with />)
+    if (match[2] !== '/') {
+      tags.push({ pos: match.index, isClosing: false, match });
+    }
+  }
+
+  // Reset regex
+  closingTagRegex.lastIndex = 0;
+  while ((match = closingTagRegex.exec(beforeClosingTag)) !== null) {
+    tags.push({ pos: match.index, isClosing: true, match });
+  }
+
+  // Sort by position
+  tags.sort((a, b) => a.pos - b.pos);
+
+  // Walk through tags from the end, tracking depth
+  for (let i = tags.length - 1; i >= 0; i--) {
+    const tag = tags[i];
+    if (tag.isClosing) {
+      depth++;
+    } else {
+      if (depth === 0) {
+        // This is the matching opening tag
+        return {
+          openingTag: tag.match[0],
+          position: tag.pos,
+        };
+      }
+      depth--;
+    }
+  }
+
+  return null;
+}

--- a/src/extension/helpers/htmlElements/parseHtmlAttributes.ts
+++ b/src/extension/helpers/htmlElements/parseHtmlAttributes.ts
@@ -1,0 +1,201 @@
+/**
+ * Extract class and id from an HTML opening tag
+ * @param tagText - The full opening tag text (e.g., '<div id="main" class="foo bar">')
+ * @returns Object with tagName, id, and classes array
+ */
+export function parseHtmlAttributes(tagText: string): {
+  tagName: string;
+  id: string | null;
+  classes: string[];
+} {
+  // Extract tag name from the opening tag
+  const tagNameMatch = /<(\w+)/i.exec(tagText);
+  const tagName = tagNameMatch ? tagNameMatch[1] : '';
+
+  // Extract id attribute (handle single/double quotes and no quotes)
+  const idMatch = /\bid\s*=\s*["']([^"']*)["']/i.exec(tagText);
+  const id = idMatch ? idMatch[1] : null;
+
+  // Extract class attribute (handle single/double quotes and no quotes)
+  const classMatch = /\bclass\s*=\s*["']([^"']*)["']/i.exec(tagText);
+  const classAttr = classMatch ? classMatch[1] : '';
+
+  // Split classes by whitespace and filter out empty strings
+  const classes = classAttr
+    .split(/\s+/)
+    .filter((cls) => cls.length > 0)
+    .filter((cls) => {
+      // Filter out Handlebars expressions (they start with {{ or contain }})
+      return !cls.includes('{{') && !cls.includes('}}');
+    });
+
+  return {
+    tagName,
+    id,
+    classes,
+  };
+}
+
+/**
+ * Common Bootstrap utility class prefixes and patterns to filter out
+ */
+const BOOTSTRAP_CLASS_PATTERNS = [
+  // Layout
+  /^container(-fluid|-sm|-md|-lg|-xl|-xxl)?$/,
+  /^row(-cols-\d+)?$/,
+  /^col(-\d+)?(-sm|-md|-lg|-xl|-xxl)?(-\d+)?$/,
+  /^offset-/,
+  /^order-/,
+  // Display
+  /^d-(none|inline|inline-block|block|grid|table|table-cell|table-row|flex|inline-flex)/,
+  // Spacing (margin and padding)
+  /^[mp][tblrxy]?-\d+$/,
+  /^[mp][tblrxy]?-auto$/,
+  /^g[xy]?-\d+$/,
+  // Flexbox
+  /^flex-(row|column|wrap|nowrap|fill|grow-|shrink-)/,
+  /^justify-content-/,
+  /^align-(items|content|self)-/,
+  // Text
+  /^text-(start|end|center|justify|wrap|nowrap|truncate|break|lowercase|uppercase|capitalize)/,
+  /^text-(primary|secondary|success|danger|warning|info|light|dark|body|muted|white|black-50|white-50)/,
+  /^fs-/,
+  /^fw-(bold|bolder|normal|light|lighter)/,
+  /^fst-(italic|normal)/,
+  /^lh-/,
+  // Background
+  /^bg-(primary|secondary|success|danger|warning|info|light|dark|body|white|transparent)/,
+  /^bg-gradient/,
+  /^bg-opacity-/,
+  // Borders
+  /^border(-top|-end|-bottom|-start)?(-\d+)?$/,
+  /^border-(primary|secondary|success|danger|warning|info|light|dark|white)/,
+  /^rounded(-top|-end|-bottom|-start|-circle|-pill)?(-\d+)?$/,
+  // Sizing
+  /^[wh]-(25|50|75|100|auto)/,
+  /^m[wh]-/,
+  /^v[wh]-/,
+  // Position
+  /^position-(static|relative|absolute|fixed|sticky)/,
+  /^(top|bottom|start|end)-/,
+  // Visibility
+  /^visible|invisible$/,
+  /^overflow-(auto|hidden|visible|scroll)/,
+  // Shadow
+  /^shadow(-sm|-lg|-none)?$/,
+  // Float
+  /^float-(start|end|none)/,
+  // Common components
+  /^btn(-outline)?-(primary|secondary|success|danger|warning|info|light|dark|link)/,
+  /^btn-(sm|lg|block)/,
+  /^badge/,
+  /^alert(-dismissible)?(-\w+)?$/,
+  /^card(-body|-header|-footer|-title|-text|-img|-img-overlay)?$/,
+  /^nav(-item|-link|-tabs|-pills)?$/,
+  /^navbar/,
+  /^dropdown/,
+  /^modal/,
+  /^form-(control|select|check|switch|label|text)/,
+  /^input-group/,
+  /^list-group(-item)?/,
+  /^table/,
+  /^pagination/,
+  /^breadcrumb/,
+];
+
+/**
+ * Check if a class name matches Bootstrap patterns
+ */
+function isBootstrapClass(className: string): boolean {
+  return BOOTSTRAP_CLASS_PATTERNS.some((pattern) => pattern.test(className));
+}
+
+/**
+ * Filter classes, prioritizing non-Bootstrap classes
+ * @param classes - Array of class names
+ * @param maxToShow - Maximum number of classes to show
+ * @returns Filtered array of class names with non-Bootstrap classes first
+ */
+function filterClasses(classes: string[], maxToShow: number): string[] {
+  if (maxToShow === 0 || classes.length <= maxToShow) {
+    return classes;
+  }
+
+  // Separate Bootstrap and non-Bootstrap classes
+  const nonBootstrap: string[] = [];
+  const bootstrap: string[] = [];
+
+  classes.forEach((cls) => {
+    if (isBootstrapClass(cls)) {
+      bootstrap.push(cls);
+    } else {
+      nonBootstrap.push(cls);
+    }
+  });
+
+  // Take non-Bootstrap classes first, then Bootstrap if space allows
+  const result: string[] = [];
+
+  // Add non-Bootstrap classes (up to limit)
+  const nonBootstrapToShow = Math.min(nonBootstrap.length, maxToShow);
+  result.push(...nonBootstrap.slice(0, nonBootstrapToShow));
+
+  // If we have room left, add some Bootstrap classes
+  const remainingSlots = maxToShow - result.length;
+  if (remainingSlots > 0) {
+    result.push(...bootstrap.slice(0, remainingSlots));
+  }
+
+  return result;
+}
+
+/**
+ * Format hint text from parsed attributes
+ * @param tagName - Element tag name (div, span, etc.)
+ * @param id - Element ID or null
+ * @param classes - Array of class names
+ * @param config - User configuration
+ * @returns Formatted hint string (e.g., "div#main.container.active")
+ */
+export function formatHintText(
+  tagName: string,
+  id: string | null,
+  classes: string[],
+  config: {
+    showIds: boolean;
+    showClasses: boolean;
+    maxClassesToShow: number;
+  }
+): string {
+  let hint = tagName;
+
+  // Add ID if enabled and present
+  if (config.showIds && id) {
+    // Filter out Handlebars expressions
+    if (!id.includes('{{') && !id.includes('}}')) {
+      hint += `#${id}`;
+    }
+  }
+
+  // Add classes if enabled and present
+  if (config.showClasses && classes.length > 0) {
+    const classesToShow =
+      config.maxClassesToShow > 0
+        ? filterClasses(classes, config.maxClassesToShow)
+        : classes;
+
+    classesToShow.forEach((cls) => {
+      hint += `.${cls}`;
+    });
+
+    // Add ellipsis if there are more classes than shown
+    if (
+      config.maxClassesToShow > 0 &&
+      classes.length > config.maxClassesToShow
+    ) {
+      hint += '...';
+    }
+  }
+
+  return hint;
+}

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -9,6 +9,7 @@ import { createDeactivate } from './deactivate';
 const extConfig: ExtensionConfig = {
   client: null,
   blockConditionDecorationType: null,
+  htmlElementDecorationType: null,
 };
 
 /**

--- a/src/server/connection/index.ts
+++ b/src/server/connection/index.ts
@@ -26,6 +26,7 @@ import onDefinition from './onDefinition/index.js';
 import onDidChangeConfiguration from './onDidChangeConfiguration.js';
 import onDidChangeContent from './onDidChangeContent.js';
 import onDidClose from './onDidClose.js';
+import onFoldingRanges from './onFoldingRanges.js';
 import {
   onDocumentFormatting,
   onDocumentOnTypeFormatting,
@@ -80,6 +81,7 @@ connection.onCompletion(onCompletion(config));
 connection.onCompletionResolve(onCompletionResolve(config));
 connection.onHover(onHover(config));
 connection.onDefinition(onDefinition(config));
+connection.onFoldingRanges(onFoldingRanges(config));
 
 // Register formatting handlers
 connection.onDocumentFormatting(onDocumentFormatting(config));

--- a/src/server/connection/onFoldingRanges.ts
+++ b/src/server/connection/onFoldingRanges.ts
@@ -1,0 +1,80 @@
+import {
+  FoldingRange,
+  FoldingRangeParams,
+} from 'vscode-languageserver/node.js';
+
+import { CurrentConnectionConfig } from '../../types/index.js';
+
+const onFoldingRanges = (config: CurrentConnectionConfig) => {
+  return (params: FoldingRangeParams): FoldingRange[] => {
+    const document = config.documents.get(params.textDocument.uri);
+    if (!document) {
+      return [];
+    }
+
+    const text = document.getText();
+    const lines = text.split('\n');
+    const foldingRanges: FoldingRange[] = [];
+
+    // Stack to track opening blocks
+    interface BlockInfo {
+      name: string;
+      startLine: number;
+      startChar: number;
+    }
+    const blockStack: BlockInfo[] = [];
+
+    // Regex patterns for Blaze block helpers
+    // Opening tags: {{#if}}, {{#each}}, {{#unless}}, {{#with}}, {{#let}}
+    const openBlockRegex =
+      /\{\{#(if|each|unless|with|let|autoform|afQuickField|afEachArrayItem|afFieldInput|afDeleteButton)\b[^}]*\}\}/g;
+    // Closing tags: {{/if}}, {{/each}}, etc.
+    const closeBlockRegex =
+      /\{\{\/(if|each|unless|with|let|autoform|afQuickField|afEachArrayItem|afFieldInput|afDeleteButton)\}\}/g;
+
+    for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+      const line = lines[lineIndex];
+
+      // Find all opening blocks in this line
+      let match: RegExpExecArray | null;
+      openBlockRegex.lastIndex = 0;
+      while ((match = openBlockRegex.exec(line)) !== null) {
+        const blockName = match[1];
+        blockStack.push({
+          name: blockName,
+          startLine: lineIndex,
+          startChar: match.index,
+        });
+      }
+
+      // Find all closing blocks in this line
+      closeBlockRegex.lastIndex = 0;
+      while ((match = closeBlockRegex.exec(line)) !== null) {
+        const blockName = match[1];
+
+        // Pop from stack and create folding range
+        // Find the most recent matching opening block
+        for (let i = blockStack.length - 1; i >= 0; i--) {
+          if (blockStack[i].name === blockName) {
+            const openBlock = blockStack[i];
+            blockStack.splice(i, 1);
+
+            // Only create folding range if it spans multiple lines
+            if (lineIndex > openBlock.startLine) {
+              foldingRanges.push({
+                startLine: openBlock.startLine,
+                endLine: lineIndex,
+                kind: undefined, // Can be 'comment', 'imports', or 'region'
+              });
+            }
+            break;
+          }
+        }
+      }
+    }
+
+    return foldingRanges;
+  };
+};
+
+export default onFoldingRanges;

--- a/src/server/connection/onInitialize.ts
+++ b/src/server/connection/onInitialize.ts
@@ -37,6 +37,7 @@ const onInitialize = (config: CurrentConnectionConfig) => {
           firstTriggerCharacter: '\n',
           moreTriggerCharacter: ['}'],
         },
+        foldingRangeProvider: true,
       },
     };
 

--- a/src/server/helpers/strings.ts
+++ b/src/server/helpers/strings.ts
@@ -12,3 +12,41 @@ export const safeParse = <T>(
     return defaultValue !== undefined ? defaultValue : null;
   }
 };
+
+export const codeInline = (text: string): string => {
+  return `\`${text}\``;
+};
+export function codeBlock(text: string): string;
+export function codeBlock(lang: string, text: string): string;
+export function codeBlock(
+  textOrLang: string,
+  textOrUndefined?: string
+): string {
+  let lang: string = 'markdown';
+  let text: string = textOrLang ?? textOrUndefined ?? '';
+
+  if (textOrUndefined !== undefined) {
+    lang = textOrLang;
+    text = textOrUndefined ?? '';
+  }
+
+  const backticks = '```';
+  return `${backticks}${lang}\n${text}\n${backticks}`;
+}
+/**
+ * Convert a string to Start Case (e.g., "helloWorld" -> "Hello world")
+ * @param str - Input string
+ * @returns Start cased string
+ */
+export const startCase = (str?: string): string => {
+  if (!str || typeof str !== 'string') {
+    return '';
+  }
+  return str
+    .replace(/([A-Z])/g, ' $1') // Add space before capital letters
+    .replace(/[_-]+/g, ' ') // Replace underscores and hyphens with spaces
+    .replace(/\s+/g, ' ') // Collapse multiple spaces
+    .trim() // Trim leading/trailing spaces
+    .toLowerCase() // Convert to lowercase
+    .replace(/^\w/, (c) => c.toUpperCase()); // Capitalize first letter
+};

--- a/src/test/server/helpers/htmlElements/findMatchingOpenTag.test.ts
+++ b/src/test/server/helpers/htmlElements/findMatchingOpenTag.test.ts
@@ -1,0 +1,179 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { findMatchingOpenTag } from '../../../../../src/extension/helpers/htmlElements/findMatchingOpenTag';
+
+describe('findMatchingOpenTag', () => {
+  it('should find matching opening tag for a simple closing tag', () => {
+    const html = '<div id="main">content</div>';
+    const closingTagPos = html.indexOf('</div>');
+    const result = findMatchingOpenTag(html, closingTagPos, 'div');
+
+    assert.ok(result);
+    assert.strictEqual(result.openingTag, '<div id="main">');
+    assert.strictEqual(result.position, 0);
+  });
+
+  it('should find matching opening tag with nested same-type elements', () => {
+    const html = '<div class="outer"><div class="inner">content</div></div>';
+    const closingTagPos = html.lastIndexOf('</div>');
+    const result = findMatchingOpenTag(html, closingTagPos, 'div');
+
+    assert.ok(result);
+    assert.strictEqual(result.openingTag, '<div class="outer">');
+    assert.strictEqual(result.position, 0);
+  });
+
+  it('should find correct opening tag for inner closing tag', () => {
+    const html = '<div class="outer"><div class="inner">content</div></div>';
+    const firstClosingTagPos = html.indexOf('</div>');
+    const result = findMatchingOpenTag(html, firstClosingTagPos, 'div');
+
+    assert.ok(result);
+    assert.strictEqual(result.openingTag, '<div class="inner">');
+    assert.ok(result.position > 0);
+  });
+
+  it('should handle deeply nested elements', () => {
+    const html = '<div><div><div><div>content</div></div></div></div>';
+    const closingTagPos = html.indexOf('</div>');
+    const result = findMatchingOpenTag(html, closingTagPos, 'div');
+
+    assert.ok(result);
+    assert.strictEqual(result.openingTag, '<div>');
+    // Should match the innermost opening tag
+    assert.strictEqual(result.position, html.lastIndexOf('<div>'));
+  });
+
+  it('should return null for self-closing tags', () => {
+    const html = '<div><img src="test.jpg" /></div>';
+    const closingTagPos = html.indexOf('</div>');
+    const result = findMatchingOpenTag(html, closingTagPos, 'img');
+
+    assert.strictEqual(result, null);
+  });
+
+  it('should handle different HTML elements', () => {
+    const elements = ['section', 'article', 'header', 'footer', 'nav'];
+    elements.forEach((tag) => {
+      const html = `<${tag} class="test">content</${tag}>`;
+      const closingTagPos = html.indexOf(`</${tag}>`);
+      const result = findMatchingOpenTag(html, closingTagPos, tag);
+
+      assert.ok(result, `Should find opening tag for ${tag}`);
+      assert.strictEqual(result.openingTag, `<${tag} class="test">`);
+    });
+  });
+
+  it('should handle mixed nesting of different elements', () => {
+    const html =
+      '<div><section><div class="inner">content</div></section></div>';
+    const innerDivClosing = html.indexOf('</div>');
+    const result = findMatchingOpenTag(html, innerDivClosing, 'div');
+
+    assert.ok(result);
+    assert.strictEqual(result.openingTag, '<div class="inner">');
+  });
+
+  it('should skip self-closing tags in the middle', () => {
+    const html = '<div><img src="test.jpg" /><br />content</div>';
+    const closingTagPos = html.indexOf('</div>');
+    const result = findMatchingOpenTag(html, closingTagPos, 'div');
+
+    assert.ok(result);
+    assert.strictEqual(result.openingTag, '<div>');
+    assert.strictEqual(result.position, 0);
+  });
+
+  it('should handle tags with no attributes', () => {
+    const html = '<div>content</div>';
+    const closingTagPos = html.indexOf('</div>');
+    const result = findMatchingOpenTag(html, closingTagPos, 'div');
+
+    assert.ok(result);
+    assert.strictEqual(result.openingTag, '<div>');
+    assert.strictEqual(result.position, 0);
+  });
+
+  it('should handle tags with complex attributes', () => {
+    const html =
+      '<div id="main" class="container active" data-value="123">content</div>';
+    const closingTagPos = html.indexOf('</div>');
+    const result = findMatchingOpenTag(html, closingTagPos, 'div');
+
+    assert.ok(result);
+    assert.strictEqual(
+      result.openingTag,
+      '<div id="main" class="container active" data-value="123">'
+    );
+    assert.strictEqual(result.position, 0);
+  });
+
+  it('should handle multiple nested structures', () => {
+    const html = `
+      <div class="outer">
+        <div class="middle">
+          <div class="inner">content</div>
+        </div>
+        <div class="sibling">more</div>
+      </div>
+    `;
+    const outerClosingPos = html.lastIndexOf('</div>');
+    const result = findMatchingOpenTag(html, outerClosingPos, 'div');
+
+    assert.ok(result);
+    assert.ok(result.openingTag.includes('class="outer"'));
+  });
+
+  it('should handle case-insensitive tag names', () => {
+    const html = '<DIV id="test">content</DIV>';
+    const closingTagPos = html.indexOf('</DIV>');
+    const result = findMatchingOpenTag(html, closingTagPos, 'DIV');
+
+    assert.ok(result);
+    assert.strictEqual(result.openingTag, '<DIV id="test">');
+  });
+
+  it('should return null when no matching opening tag found', () => {
+    const html = '</div>';
+    const closingTagPos = 0;
+    const result = findMatchingOpenTag(html, closingTagPos, 'div');
+
+    assert.strictEqual(result, null);
+  });
+
+  it('should handle tags with line breaks in attributes', () => {
+    const html = `<div
+      id="main"
+      class="container"
+    >content</div>`;
+    const closingTagPos = html.indexOf('</div>');
+    const result = findMatchingOpenTag(html, closingTagPos, 'div');
+
+    assert.ok(result);
+    assert.ok(result.openingTag.includes('id="main"'));
+  });
+
+  it('should handle common self-closing tags', () => {
+    const selfClosingTags = ['img', 'br', 'hr', 'input', 'meta', 'link'];
+    selfClosingTags.forEach((tag) => {
+      const html = `<div><${tag} /></div>`;
+      const result = findMatchingOpenTag(html, html.indexOf(`<${tag}`), tag);
+      assert.strictEqual(
+        result,
+        null,
+        `${tag} should return null as it's self-closing`
+      );
+    });
+  });
+
+  it('should correctly handle alternating nested tags', () => {
+    const html = '<div><span><div><span>content</span></div></span></div>';
+    const firstSpanClosing = html.indexOf('</span>');
+    const result = findMatchingOpenTag(html, firstSpanClosing, 'span');
+
+    assert.ok(result);
+    // Should match the innermost span
+    const lastSpanOpening = html.lastIndexOf('<span>');
+    assert.strictEqual(result.position, lastSpanOpening);
+  });
+});

--- a/src/test/server/helpers/htmlElements/parseHtmlAttributes.test.ts
+++ b/src/test/server/helpers/htmlElements/parseHtmlAttributes.test.ts
@@ -1,0 +1,211 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import {
+  formatHintText,
+  parseHtmlAttributes,
+} from '../../../../../src/extension/helpers/htmlElements/parseHtmlAttributes';
+
+describe('parseHtmlAttributes', () => {
+  it('should extract tag name, id, and classes from a basic opening tag', () => {
+    const result = parseHtmlAttributes(
+      '<div id="main" class="container active">'
+    );
+    assert.strictEqual(result.tagName, 'div');
+    assert.strictEqual(result.id, 'main');
+    assert.deepStrictEqual(result.classes, ['container', 'active']);
+  });
+
+  it('should extract tag name only when no id or classes', () => {
+    const result = parseHtmlAttributes('<div>');
+    assert.strictEqual(result.tagName, 'div');
+    assert.strictEqual(result.id, null);
+    assert.deepStrictEqual(result.classes, []);
+  });
+
+  it('should extract id without classes', () => {
+    const result = parseHtmlAttributes('<section id="header">');
+    assert.strictEqual(result.tagName, 'section');
+    assert.strictEqual(result.id, 'header');
+    assert.deepStrictEqual(result.classes, []);
+  });
+
+  it('should extract classes without id', () => {
+    const result = parseHtmlAttributes('<div class="btn btn-primary">');
+    assert.strictEqual(result.tagName, 'div');
+    assert.strictEqual(result.id, null);
+    assert.deepStrictEqual(result.classes, ['btn', 'btn-primary']);
+  });
+
+  it('should handle single quotes', () => {
+    const result = parseHtmlAttributes("<div id='main' class='container'>");
+    assert.strictEqual(result.tagName, 'div');
+    assert.strictEqual(result.id, 'main');
+    assert.deepStrictEqual(result.classes, ['container']);
+  });
+
+  it('should handle multiple classes with various spacing', () => {
+    const result = parseHtmlAttributes(
+      '<div class="  class1   class2  class3  ">'
+    );
+    assert.strictEqual(result.tagName, 'div');
+    assert.deepStrictEqual(result.classes, ['class1', 'class2', 'class3']);
+  });
+
+  it('should filter out Handlebars expressions in classes', () => {
+    const result = parseHtmlAttributes(
+      '<div class="container {{#if active}}active{{/if}}">'
+    );
+    assert.strictEqual(result.tagName, 'div');
+    // Should only include 'container', not the Handlebars part
+    assert.deepStrictEqual(result.classes, ['container']);
+  });
+
+  it('should handle empty class attribute', () => {
+    const result = parseHtmlAttributes('<div class="">');
+    assert.strictEqual(result.tagName, 'div');
+    assert.deepStrictEqual(result.classes, []);
+  });
+
+  it('should handle case-insensitive tag names', () => {
+    const result = parseHtmlAttributes('<DIV id="main">');
+    assert.strictEqual(result.tagName, 'DIV');
+    assert.strictEqual(result.id, 'main');
+  });
+
+  it('should handle various HTML elements', () => {
+    const elements = [
+      'div',
+      'span',
+      'section',
+      'article',
+      'header',
+      'footer',
+      'nav',
+      'main',
+    ];
+    elements.forEach((tag) => {
+      const result = parseHtmlAttributes(`<${tag} id="test">`);
+      assert.strictEqual(result.tagName, tag);
+      assert.strictEqual(result.id, 'test');
+    });
+  });
+});
+
+describe('formatHintText', () => {
+  it('should format tag with id only', () => {
+    const result = formatHintText('div', 'main', [], {
+      showIds: true,
+      showClasses: true,
+      maxClassesToShow: 3,
+    });
+    assert.strictEqual(result, 'div#main');
+  });
+
+  it('should format tag with classes only', () => {
+    const result = formatHintText('div', null, ['container', 'active'], {
+      showIds: true,
+      showClasses: true,
+      maxClassesToShow: 3,
+    });
+    assert.strictEqual(result, 'div.container.active');
+  });
+
+  it('should format tag with id and classes', () => {
+    const result = formatHintText('div', 'main', ['container', 'active'], {
+      showIds: true,
+      showClasses: true,
+      maxClassesToShow: 3,
+    });
+    assert.strictEqual(result, 'div#main.container.active');
+  });
+
+  it('should respect showIds=false', () => {
+    const result = formatHintText('div', 'main', ['container'], {
+      showIds: false,
+      showClasses: true,
+      maxClassesToShow: 3,
+    });
+    assert.strictEqual(result, 'div.container');
+  });
+
+  it('should respect showClasses=false', () => {
+    const result = formatHintText('div', 'main', ['container', 'active'], {
+      showIds: true,
+      showClasses: false,
+      maxClassesToShow: 3,
+    });
+    assert.strictEqual(result, 'div#main');
+  });
+
+  it('should truncate classes with ellipsis when over limit', () => {
+    const result = formatHintText(
+      'div',
+      null,
+      ['class1', 'class2', 'class3', 'class4', 'class5'],
+      {
+        showIds: true,
+        showClasses: true,
+        maxClassesToShow: 3,
+      }
+    );
+    assert.strictEqual(result, 'div.class1.class2.class3...');
+  });
+
+  it('should show all classes when maxClassesToShow is 0', () => {
+    const result = formatHintText(
+      'div',
+      null,
+      ['class1', 'class2', 'class3', 'class4', 'class5'],
+      {
+        showIds: true,
+        showClasses: true,
+        maxClassesToShow: 0,
+      }
+    );
+    assert.strictEqual(result, 'div.class1.class2.class3.class4.class5');
+  });
+
+  it('should not add ellipsis when exactly at limit', () => {
+    const result = formatHintText('div', null, ['class1', 'class2', 'class3'], {
+      showIds: true,
+      showClasses: true,
+      maxClassesToShow: 3,
+    });
+    assert.strictEqual(result, 'div.class1.class2.class3');
+  });
+
+  it('should filter out Handlebars in id', () => {
+    const result = formatHintText('div', '{{dynamicId}}', ['container'], {
+      showIds: true,
+      showClasses: true,
+      maxClassesToShow: 3,
+    });
+    assert.strictEqual(result, 'div.container');
+  });
+
+  it('should prioritize non-Bootstrap classes', () => {
+    const result = formatHintText(
+      'div',
+      null,
+      ['my-component', 'container', 'custom-class', 'row', 'd-flex', 'special'],
+      {
+        showIds: true,
+        showClasses: true,
+        maxClassesToShow: 3,
+      }
+    );
+    // Should show custom classes first, not Bootstrap utility classes
+    assert.ok(result.includes('my-component'));
+    assert.ok(result.includes('custom-class'));
+    assert.ok(result.includes('special'));
+  });
+
+  it('should format with just tag name when no id or classes', () => {
+    const result = formatHintText('div', null, [], {
+      showIds: true,
+      showClasses: true,
+      maxClassesToShow: 3,
+    });
+    assert.strictEqual(result, 'div');
+  });
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -225,6 +225,9 @@ export type ExtensionConfig = {
   /** Decoration type for block-condition hints
    * - created dynamically based on settings */
   blockConditionDecorationType: vscode.TextEditorDecorationType | null;
+  /** Decoration type for HTML element closing tag hints
+   * - created dynamically based on settings */
+  htmlElementDecorationType: vscode.TextEditorDecorationType | null;
 };
 
 export type GlobalHelperInfo = {

--- a/test-project/imports/ui/test-html-hints.html
+++ b/test-project/imports/ui/test-html-hints.html
@@ -1,0 +1,88 @@
+<template name="testHtmlHints">
+  <!-- Test 1: Element with id only (should show: div#main) -->
+  <div id="main">
+    <h1>Test Page</h1>
+    <p>This div has only an ID</p>
+    <p>Line 4</p>
+    <p>Line 5</p>
+    <p>Line 6</p>
+  </div>
+
+  <!-- Test 2: Element with classes only (should show: div.container.primary.active) -->
+  <div class="container primary active">
+    <h2>Section Title</h2>
+    <p>This div has only classes</p>
+    <p>Line 4</p>
+    <p>Line 5</p>
+    <p>Line 6</p>
+  </div>
+
+  <!-- Test 3: Element with id and classes (should show: div#header.header-main.sticky) -->
+  <div id="header" class="header-main sticky">
+    <nav>Navigation</nav>
+    <p>This div has both ID and classes</p>
+    <p>Line 4</p>
+    <p>Line 5</p>
+    <p>Line 6</p>
+  </div>
+
+  <!-- Test 4: Nested divs with same class names -->
+  <div class="outer-container">
+    <div class="inner">
+      <h3>Inner Content</h3>
+      <p>Line 1</p>
+      <p>Line 2</p>
+      <p>Line 3</p>
+      <p>Line 4</p>
+    </div>
+    <div class="inner">
+      <h3>Another Inner</h3>
+      <p>Line 1</p>
+      <p>Line 2</p>
+      <p>Line 3</p>
+      <p>Line 4</p>
+    </div>
+  </div>
+
+  <!-- Test 5: Element with many classes (should truncate to 3 by default) -->
+  <div class="class1 class2 class3 class4 class5 class6">
+    <p>This div has many classes</p>
+    <p>Should show: div.class1.class2.class3...</p>
+    <p>Line 3</p>
+    <p>Line 4</p>
+    <p>Line 5</p>
+  </div>
+
+  <!-- Test 6: Short elements (less than 5 lines) - should NOT show hints -->
+  <div class="short">
+    <p>This is short</p>
+  </div>
+
+  <!-- Test 7: Complex nested structure -->
+  <div id="main-wrapper" class="wrapper full-width">
+    <header class="site-header">
+      <div class="logo">Logo</div>
+      <nav class="main-nav">
+        <ul>
+          <li>Item 1</li>
+          <li>Item 2</li>
+        </ul>
+      </nav>
+    </header>
+    <main class="content-area">
+      <article class="post">
+        <h1>Article Title</h1>
+        <p>Article content line 1</p>
+        <p>Article content line 2</p>
+        <p>Article content line 3</p>
+        <p>Article content line 4</p>
+      </article>
+    </main>
+    <footer class="site-footer">
+      <p>Footer content</p>
+      <p>More footer</p>
+      <p>Even more</p>
+      <p>Last line</p>
+    </footer>
+  </div>
+</template>


### PR DESCRIPTION
# HTML Element Closing Tag Tooltips

- Resolves #63 

## Overview

Adds visual inline hints showing class names and IDs at closing tags of HTML elements that span multiple lines, making it easier to navigate deeply nested HTML structures.

## Features Added

### HTML Element Closing Tag Hints

- Shows hints in CSS selector format (e.g., `div#main.container.primary`)
- Configurable minimum line threshold (default: 15 lines)
- Smart filtering that prioritizes custom classes over Bootstrap utility classes
- Respects existing comments (won't add hints if comment already exists)
- Excludes self-closing tags (`<img>`, `<br>`, `<input>`, etc.)
- Hover tooltips display element type and line range

### Configuration Options

New settings under `meteorLanguageServer.htmlElementHints`:

- `enabled` - Enable/disable the feature (default: true)
- `minimumLines` - Minimum lines to show hint (default: 15)
- `color` - Hint color (default: "#727272")
- `fontStyle` - Font style: normal, italic, or bold (default: italic)
- `margin` - CSS margin for hints (default: "0 0 0 0.75em")
- `showClasses` - Include class names (default: true)
- `showIds` - Include IDs (default: true)
- `maxClassesToShow` - Max classes to display, 0 = unlimited (default: 3)

## Documentation

- Updated README with feature documentation and examples
- Updated FEATURES.md with detailed configuration and usage
- Added example configuration file: `example-settings-htmlElementHints.jsonc`

## Testing

- Added comprehensive unit tests for HTML tag matching and attribute parsing
- Tests cover nested elements, self-closing tags, Bootstrap class filtering
- Added example template for manual testing

## Bug Fixes

- Fixed test script quote escaping in package.json
- Added hover messages to block condition hints with line numbers

## Additional Enhancements

- Added folding range provider for Blaze block helpers
- Extended folding support to autoform and related helpers
- Added code formatting helpers (`codeBlock`, `codeInline`, `startCase`) for improved tooltips
